### PR TITLE
Bump Guava to make reflections work with Java 11

### DIFF
--- a/core/src/main/java/com/metamx/rdiclient/RdiClientImpl.java
+++ b/core/src/main/java/com/metamx/rdiclient/RdiClientImpl.java
@@ -390,7 +390,7 @@ public class RdiClientImpl<T> implements RdiClient<T>
   )
   {
     final SettableFuture<HttpResponseStatus> retVal = SettableFuture.create();
-    final ListenableFuture<HttpResponseStatus> response = Futures.transform(
+    final ListenableFuture<HttpResponseStatus> response = Futures.transformAsync(
         httpClient.go(request, new StatusResponseHandler(Charsets.UTF_8)),
         new AsyncFunction<StatusResponseHolder, HttpResponseStatus>()
         {

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
         <artifactId>validation-api</artifactId>
         <version>1.0.0.GA</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>25.0-jre</version>
+      </dependency>
 
       <!-- Jackson -->
       <dependency>


### PR DESCRIPTION
With Java 11 and Guava 14.0.x `com.google.common.reflectClassPath.from(ClassLoader.getSystemClassLoader()).getAllClasses()` returns an empty `Set`. From a consumers perspective it is not possible to upgrade Guava on that side since `rdi-client-java` depends on a version of Guava which has had a non-compatible API change.

Resolves: metamx/rdi-client-java#7